### PR TITLE
ARM: dts: qcom: Disable wsa881x codecs

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm-wsa881x.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm-wsa881x.dtsi
@@ -18,27 +18,19 @@
 			#size-cells = <0>;
 
 			wsa881x_0211: wsa881x@20170211 {
-				compatible = "qcom,wsa881x";
-				reg = <0x00 0x20170211>;
-				qcom,spkr-sd-n-node = <&wsa_spkr_wcd_sd1>;
+				status = "disabled";
 			};
 
 			wsa881x_0212: wsa881x@20170212 {
-				compatible = "qcom,wsa881x";
-				reg = <0x00 0x20170212>;
-				qcom,spkr-sd-n-node = <&wsa_spkr_wcd_sd2>;
+				status = "disabled";
 			};
 
 			wsa881x_0213: wsa881x@21170213 {
-				compatible = "qcom,wsa881x";
-				reg = <0x00 0x21170213>;
-				qcom,spkr-sd-n-node = <&wsa_spkr_wcd_sd1>;
+				status = "disabled";
 			};
 
 			wsa881x_0214: wsa881x@21170214 {
-				compatible = "qcom,wsa881x";
-				reg = <0x00 0x21170214>;
-				qcom,spkr-sd-n-node = <&wsa_spkr_wcd_sd2>;
+				status = "disabled";
 			};
 		};
 	};


### PR DESCRIPTION
Our device does not have this codecs...

kernel dmesg:
[   12.299956]wsa881x: probe of wsa881x.20170211 failed with error -22
[   13.002387]wsa881x: probe of wsa881x.20170212 failed with error -22
[   13.008922]wsa881x: probe of wsa881x.21170213 failed with error -22
[   13.010005]wsa881x: probe of wsa881x.21170214 failed with error -22