### PR TITLE
drivers: qpnp-fg-gen3: Delete battery capacity learning

### DIFF
--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -4293,6 +4293,7 @@ static int fg_psy_set_property(struct power_supply *psy,
 		}
 		break;
 	case POWER_SUPPLY_PROP_CHARGE_FULL:
+/*
 		if (chip->cl.active) {
 			pr_warn("Capacity learning active!\n");
 			return 0;
@@ -4301,6 +4302,7 @@ static int fg_psy_set_property(struct power_supply *psy,
 			pr_err("charge_full is out of bounds\n");
 			return -EINVAL;
 		}
+*/
 		chip->cl.learned_cc_uah = pval->intval;
 		rc = fg_save_learned_cap_to_sram(chip);
 		if (rc < 0)


### PR DESCRIPTION
Some users have replaced the expanded battery, and the actual charging capacity will be limited between 3600mah and 3800mah.

You can use the following command to change the actual battery charge capacity:
echo 'battery capacity x 1000' > /sys/class/power_supply/bms/charge_full

such as:
echo '4000000' > /sys/class/power_supply/bms/charge_full