### PR TITLE
ARM: dts-xiaomi: Correctly enable panel-allow-phy-poweroff mode

### DIFF
--- a/arch/arm64/boot/dts/qcom/beryllium-p0.dtsi
+++ b/arch/arm64/boot/dts/qcom/beryllium-p0.dtsi
@@ -1144,6 +1144,10 @@
 	mi,pd_vbus_max_limit = <9000000>;
 };
 
+&mdss_dsi_phy0 {
+	qcom,panel-allow-phy-poweroff;
+};
+
 &soc {
 	ssc_sensors: qcom,msm-ssc-sensors {
 		compatible = "qcom,msm-ssc-sensors";

--- a/arch/arm64/boot/dts/qcom/dipper-p0.dtsi
+++ b/arch/arm64/boot/dts/qcom/dipper-p0.dtsi
@@ -1246,6 +1246,9 @@
 	mi,pd_vbus_max_limit = <9000000>;
 };
 
+&mdss_dsi_phy0 {
+	qcom,panel-allow-phy-poweroff;
+};
 
 
 &soc {

--- a/arch/arm64/boot/dts/qcom/dsi-panel-ebbg-fhd-ft8716-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ebbg-fhd-ft8716-video.dtsi
@@ -84,7 +84,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-ebbg-fhd-ft8719-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ebbg-fhd-ft8719-video.dtsi
@@ -59,7 +59,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-gvo-fhd-rm69299-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-gvo-fhd-rm69299-cmd.dtsi
@@ -60,7 +60,6 @@
 		/* qcom,esd-err-irq-gpio = <&tlmm 52 0>; */
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 		qcom,mdss-dsi-display-timings {
 			timing@0{
 				qcom,mdss-dsi-panel-width = <1080>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-hx83112a-truly-singlemipi-fhd-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-hx83112a-truly-singlemipi-fhd-video.dtsi
@@ -46,7 +46,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0 {

--- a/arch/arm64/boot/dts/qcom/dsi-panel-hx8399-truly-singlemipi-fhd-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-hx8399-truly-singlemipi-fhd-video.dtsi
@@ -46,7 +46,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0 {

--- a/arch/arm64/boot/dts/qcom/dsi-panel-jdi-fhd-nt35596s-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-jdi-fhd-nt35596s-video.dtsi
@@ -66,7 +66,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-jdi-fhd-r63452-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-jdi-fhd-r63452-cmd.dtsi
@@ -60,7 +60,6 @@
 		qcom,mdss-night-brightness = <7 25 43 61>;
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 		qcom,mdss-dsi-display-timings {
 			timing@0{
 				qcom,mdss-dsi-panel-width = <1080>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-nt35695b-truly-fhd-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-nt35695b-truly-fhd-cmd.dtsi
@@ -44,7 +44,6 @@
 		qcom,mdss-dsi-mdp-trigger = "none";
 
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-nt35695b-truly-fhd-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-nt35695b-truly-fhd-video.dtsi
@@ -40,7 +40,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-rm67195-amoled-fhd-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-rm67195-amoled-fhd-cmd.dtsi
@@ -50,7 +50,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-samsung-fhd-ea8076-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-samsung-fhd-ea8076-cmd.dtsi
@@ -67,7 +67,6 @@
 		qcom,mdss-dsi-panel-dc-threshold = <610>;
 
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea8074-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ss-fhd-ea8074-cmd.dtsi
@@ -63,7 +63,6 @@
 		qcom,dispparam-enabled;
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 		qcom,mdss-dsi-display-timings {
 			timing@0{
 				qcom,mdss-dsi-panel-width = <1080>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-ss-notch-fhd-ea8074-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-ss-notch-fhd-ea8074-cmd.dtsi
@@ -63,7 +63,6 @@
 		qcom,mdss-panel-on-dimming-delay = <200>;
 		qcom,mdss-dsi-panel-dc-threshold = <320>;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 		qcom,mdss-dsi-display-timings {
 			timing@0{
 				qcom,mdss-dsi-panel-width = <1080>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-tianma-fhd-nt36672a-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-tianma-fhd-nt36672a-video.dtsi
@@ -60,7 +60,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-tianma-fhd-rm69299-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-tianma-fhd-rm69299-cmd.dtsi
@@ -59,7 +59,6 @@
 		qcom,dispparam-enabled;
 		/* qcom,esd-err-irq-gpio = <&tlmm 52 0>; */
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 		qcom,mdss-dsi-display-timings {
 			timing@0{
 				qcom,mdss-dsi-panel-width = <1080>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-visionox-fhd-r66455-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-visionox-fhd-r66455-cmd.dtsi
@@ -69,7 +69,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/dsi-panel-visionox-fhd-r66455-vid.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-visionox-fhd-r66455-vid.dtsi
@@ -64,7 +64,6 @@
 
 		qcom,ulps-enabled;
  		qcom,suspend-ulps-enabled;
-		qcom,panel-allow-phy-poweroff;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{

--- a/arch/arm64/boot/dts/qcom/equuleus-p0.dtsi
+++ b/arch/arm64/boot/dts/qcom/equuleus-p0.dtsi
@@ -1018,6 +1018,9 @@
 			mi,pd_vbus_max_limit = <9000000>;
 };
 
+&mdss_dsi_phy0 {
+	qcom,panel-allow-phy-poweroff;
+};
 
 
 &soc {

--- a/arch/arm64/boot/dts/qcom/perseus-p0.dtsi
+++ b/arch/arm64/boot/dts/qcom/perseus-p0.dtsi
@@ -930,6 +930,10 @@
 	mi,pd_vbus_max_limit = <9000000>;
 };
 
+&mdss_dsi_phy0 {
+	qcom,panel-allow-phy-poweroff;
+};
+
 &qusb_phy0 {
 		pinctrl-names = "atest_usb13_suspend","atest_usb13_active";
 		pinctrl-0 = <&atest_usb13_suspend>;

--- a/arch/arm64/boot/dts/qcom/polaris-p0.dtsi
+++ b/arch/arm64/boot/dts/qcom/polaris-p0.dtsi
@@ -1170,3 +1170,6 @@
 			mi,pd_vbus_max_limit = <9000000>;
 };
 
+&mdss_dsi_phy0 {
+	qcom,panel-allow-phy-poweroff;
+};

--- a/arch/arm64/boot/dts/qcom/ursa-p0.dtsi
+++ b/arch/arm64/boot/dts/qcom/ursa-p0.dtsi
@@ -1009,6 +1009,9 @@
 			mi,pd_vbus_max_limit = <9000000>;
 };
 
+&mdss_dsi_phy0 {
+	qcom,panel-allow-phy-poweroff;
+};
 
 
 &soc {


### PR DESCRIPTION
* phy regulator parse is defined on mdss_dsi_phy, not on dsi-display
* After applying c935f4d27f1a, querying the status via sysfs shows N
  with a Polaris device:
  /sys/kernel/debug/dsi_jdi_fhd_nt35596s_video_display/dsi-phy-0_allow_phy_power_off

* sdm845 has 2 phy regulators, mdss_dsi_phy0 and mdss_dsi_phy1.
* It is known in sdm845-xiaomi-sde-display.dtsi that
  mdss_dsi_phy0 is used in the screen panels on our device.
* So we only apply the mdss_dsi_phy0 part of the changes.

* After applying this patch:
  cat /sys/kernel/debug/dsi_jdi_fhd_nt35596s_video_display/dsi-phy-0_allow_phy_power_off
  Y

Fixes: c935f4d27f1a ("arm64: boot: dsi-panel: enable ULPS")
Change-Id: I5dd451ae2ce859bd0a2017ade55360a08ace6bbd