### PR TITLE
drivers: gpu-drm: Clean up imported duplicate Xiaomi drm changes

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
@@ -2808,21 +2808,6 @@ static int dsi_panel_parse_bl_config(struct dsi_panel *panel,
 		panel->bl_config.bl_update = BL_UPDATE_NONE;
 	}
 
-	panel->bl_config.dcs_type_ss = of_property_read_bool(of_node,
-						"qcom,mdss-dsi-bl-dcs-type-ss");
-
-
-	data = of_get_property(of_node, "qcom,bl-update-flag", NULL);
-	if (!data) {
-		panel->bl_config.bl_update = BL_UPDATE_NONE;
-	} else if (!strcmp(data, "delay_until_first_frame")) {
-		panel->bl_config.bl_update = BL_UPDATE_DELAY_UNTIL_FIRST_FRAME;
-	} else {
-		pr_debug("[%s] No valid bl-update-flag: %s\n",
-						panel->name, data);
-		panel->bl_config.bl_update = BL_UPDATE_NONE;
-	}
-
 	rc = of_property_read_u32(of_node, "qcom,bl-update-delay", &val);
 	if (rc) {
 		pr_debug("[%s] bl-update-delay unspecified, defaulting to zero\n",
@@ -2834,18 +2819,6 @@ static int dsi_panel_parse_bl_config(struct dsi_panel *panel,
 
 	panel->bl_config.bl_scale = MAX_BL_SCALE_LEVEL;
 	panel->bl_config.bl_scale_ad = MAX_AD_BL_SCALE_LEVEL;
-
-	panel->bl_config.dcs_type_ss = of_property_read_bool(of_node,
-						"qcom,mdss-dsi-bl-dcs-type-ss");
-
-	rc = of_property_read_u32(of_node, "qcom,bl-update-delay", &val);
-	if (rc) {
-		pr_debug("[%s] bl-update-delay unspecified, defaulting to zero\n",
-			 panel->name);
-		panel->bl_config.bl_update_delay = 0;
-	} else {
-		panel->bl_config.bl_update_delay = val;
-	}
 
 	rc = of_property_read_u32(of_node, "qcom,mdss-dsi-bl-min-level", &val);
 	if (rc) {


### PR DESCRIPTION
* Align with LineageOS commit: https://github.com/LineageOS/android_kernel_xiaomi_sdm845/commit/5b086e57

Test: In the JDI panel MIX 2S starts normally,
      the lock screen lights up the screen 20 times without problems.

Fixes: 895a439 ("drivers: drm: Update to the latest Q changes from Xiaomi")
Co-authored-by: Bruno Martins <bgcngm@gmail.com>
Co-authored-by: zhaoyuenan <zhaoyuenan@zhaoyuenan>
Change-Id: Ie59c30e617b3bb722087a7078ce96d1a70fe2a68