### PR TITLE
f2fs: Force DEF_CP_INTERVAL to 200 secs after `8f3f69db`

### DIFF
--- a/fs/f2fs/f2fs.h
+++ b/fs/f2fs/f2fs.h
@@ -193,7 +193,7 @@ enum {
 #define DEF_MAX_DISCARD_ISSUE_TIME	60000	/* 60 s, if no candidates */
 #define DEF_DISCARD_URGENT_UTIL		80	/* do more discard over 80% */
 #define DEF_MAX_DISCARD_URGENT_ISSUE_TIME	10000	/* 10 s, if no candidates on high utilization */
-#define DEF_CP_INTERVAL			60	/* 60 secs */
+#define DEF_CP_INTERVAL			200	/* 200 secs */
 #define DEF_IDLE_INTERVAL		5	/* 5 secs */
 #define DEF_DISABLE_INTERVAL		5	/* 5 secs */
 #define DEF_DISABLE_QUICK_INTERVAL	1	/* 1 secs */


### PR DESCRIPTION
* The kernel is currently using arter97's rapid GC
  Since rapid GC conflicts with default GC behavior,
  Need to rename f2fs sysfs or dirty_segments
  to avoid Android reading it and try to run GC [1]

* But at the same time lost Android F2FS tuning [2],
  Because f2fs is still used instead of f2fs_dev in init.rc,
  Hardcoding this in the kernel solves the problem.

[1]: 8f3f69db ("f2fs: rename /sys/fs/f2fs")
[2]: https://github.com/aosp-mirror/platform_system_core/commit/f65df964
[2-1]: https://github.com/PixelExperience/system_core/blob/c66a0555/rootdir/init.rc#L1071

Change test: format MIX 2S userdata partition as
             F2FS boot normally and use cat command to check
             node return value.

  The cat command used:
  cat /sys/fs/f2fs_dev/sda21/cp_interval
  200

Change-Id: Ie20557258a1272b0a62e66d8b9801ba270f8299e