### PR TITLE
f2fs: hardcode cp_interval to 200s after merging rapid GC

### DIFF
--- a/fs/f2fs/f2fs.h
+++ b/fs/f2fs/f2fs.h
@@ -193,7 +193,7 @@ enum {
 #define DEF_MAX_DISCARD_ISSUE_TIME	60000	/* 60 s, if no candidates */
 #define DEF_DISCARD_URGENT_UTIL		80	/* do more discard over 80% */
 #define DEF_MAX_DISCARD_URGENT_ISSUE_TIME	10000	/* 10 s, if no candidates on high utilization */
-#define DEF_CP_INTERVAL			60	/* 60 secs */
+#define DEF_CP_INTERVAL			200	/* 200 secs */
 #define DEF_IDLE_INTERVAL		5	/* 5 secs */
 #define DEF_DISABLE_INTERVAL		5	/* 5 secs */
 #define DEF_DISABLE_QUICK_INTERVAL	1	/* 1 secs */


### PR DESCRIPTION
In ("f2fs: rename /sys/fs/f2fs") mentions:
fsmgr and vold tries to read nodes from here and run GC by itself.

Since it conflicts with rapid GC(not to mention less effective), rename /sys/fs/f2fs to /sys/fs/f2fs_dev to avoid Android reading it entirely.

We could rename gc_urgent and dirty_segments but this approach seems better as it'll still be detected as a f2fs volume and try to run GC.

But also because of sysfs name change, we will lose AOSP F2FS tuning[1].

Since our device is using ext4 by default, adding it to the device tree will add another useless warning, so it is hardcoded in the kernel

[1]: https://android.googlesource.com/platform/system/core/+/refs/tags/android-13.0.0_r6/rootdir/init.rc#1094

* Aquarius223: Add instructions for xiaomi sdm845 device

Change-Id: I747e9e20371719055f5fd6abaf0e47645c99ac64