### PR TITLE
drivers: gpu: drm: Remove duplicate command flag changes

### DIFF
--- a/drivers/gpu/drm/drm_mipi_dsi.c
+++ b/drivers/gpu/drm/drm_mipi_dsi.c
@@ -364,8 +364,6 @@ static ssize_t mipi_dsi_device_transfer(struct mipi_dsi_device *dsi,
 		msg->flags |= MIPI_DSI_MSG_USE_LPM;
 	msg->flags |= MIPI_DSI_MSG_LASTCOMMAND;
 
-	msg->flags |= MIPI_DSI_MSG_LASTCOMMAND;
-
 	return ops->transfer(dsi->host, msg);
 }
 


### PR DESCRIPTION
* Delete redundant changes from xiaomi, duplicated with commit efa9024e.

Test: On the polaris device, switch the screen 10 times to
      adjust the brightness without any problem.

Fixes: 852c9ebb ("drivers: gpu: drm: Import Xiaomi changes")
Change-Id: Ie686fc52ebb051ea7da6a80cca60dfa278b751ee